### PR TITLE
fix config path & format

### DIFF
--- a/docs/gen_ref_pages.py
+++ b/docs/gen_ref_pages.py
@@ -18,8 +18,8 @@ for path in sorted(Path("src").rglob("*.py")):
     elif parts[-1] == "__main__":
         continue
 
-    with mkdocs_gen_files.open(full_doc_path, "w") as fd:
+    with mkdocs_gen_files.open(full_doc_path, "w") as fobj:
         identifier = ".".join(parts)
-        print("::: " + identifier, file=fd)
+        print("::: " + identifier, file=fobj)
 
     mkdocs_gen_files.set_edit_path(full_doc_path, path)

--- a/src/iterative_telemetry/__init__.py
+++ b/src/iterative_telemetry/__init__.py
@@ -222,7 +222,7 @@ def _find_or_create_user_id():
 
             # only for non-DVC packages,
             # write legacy file in case legacy DVC is installed later
-            if not old.exists() and uid.lower() != "do-not-track":
+            if not old.exists() and uid.lower() != DO_NOT_TRACK_VALUE.lower():
                 json.dump({"user_id": uid}, old.open("w", encoding="utf8"))
 
             return uid

--- a/src/iterative_telemetry/__init__.py
+++ b/src/iterative_telemetry/__init__.py
@@ -154,7 +154,7 @@ class IterativeTelemetryLogger:
             # "scm_class": _scm_in_use(),
             **_system_info(),
             "user_id": _find_or_create_user_id(),
-            "group_id": _find_or_create_user_id(),  # TODO
+            "group_id": "",  # TODO
         }
 
 

--- a/src/iterative_telemetry/__init__.py
+++ b/src/iterative_telemetry/__init__.py
@@ -214,16 +214,16 @@ def _find_or_create_user_id():
         ):
             uid = generate_id()
             if new.exists():
-                uid = new.read_text(encoding="utf8").strip()
+                uid = json.load(new.open(encoding="utf8"))["user_id"]
             else:
                 if old.exists():
                     uid = json.load(old.open(encoding="utf8"))["user_id"]
-                new.write_text(uid, encoding="utf8")
+                json.dump({"user_id": uid}, new.open("w", encoding="utf8"))
 
             # only for non-DVC packages,
             # write legacy file in case legacy DVC is installed later
             if not old.exists() and uid.lower() != "do-not-track":
-                old.write_text(f'{{"user_id": "{uid}"}}', encoding="utf8")
+                json.dump({"user_id": uid}, old.open("w", encoding="utf8"))
 
             return uid
     except Timeout:

--- a/src/iterative_telemetry/__init__.py
+++ b/src/iterative_telemetry/__init__.py
@@ -196,8 +196,8 @@ def generate_id():
 def _find_or_create_user_id():
     """
     The user's ID is stored on a file under the global config directory.
-    The file should contain a single string:
-        16fd2706-8baf-433b-82eb-8c7fada847da
+    The file should contain JSON with a `user_id` key:
+        {"user_id": "16fd2706-8baf-433b-82eb-8c7fada847da"}
     IDs are generated randomly with UUID4.
     """
     # DVC backwards-compatibility

--- a/src/iterative_telemetry/__init__.py
+++ b/src/iterative_telemetry/__init__.py
@@ -188,15 +188,15 @@ def _system_info():
 
 
 def generate_id():
-    """TODO: check environ for CI-based ID"""
-    return str(uuid.uuid4())
+    """A randomly generated ID string"""
+    return str(uuid.uuid4())  # TODO: CI env-based ID
 
 
 @lru_cache(None)
 def _find_or_create_user_id():
     """
     The user's ID is stored on a file under the global config directory.
-    The file should contain JSON with a `user_id` key:
+    The file should contain a JSON with a "user_id" key:
         {"user_id": "16fd2706-8baf-433b-82eb-8c7fada847da"}
     IDs are generated randomly with UUID4.
     """

--- a/src/iterative_telemetry/__init__.py
+++ b/src/iterative_telemetry/__init__.py
@@ -214,16 +214,16 @@ def _find_or_create_user_id():
         ):
             uid = generate_id()
             if new.exists():
-                uid = new.read_text().strip()
+                uid = new.read_text(encoding="utf8").strip()
             else:
                 if old.exists():
                     uid = json.load(old.open(encoding="utf8"))["user_id"]
-                new.write_text(uid)
+                new.write_text(uid, encoding="utf8")
 
             # only for non-DVC packages,
             # write legacy file in case legacy DVC is installed later
             if not old.exists() and uid.lower() != "do-not-track":
-                old.write_text(f'{{"user_id": "{uid}"}}')
+                old.write_text(f'{{"user_id": "{uid}"}}', encoding="utf8")
 
             return uid
     except Timeout:

--- a/src/iterative_telemetry/__init__.py
+++ b/src/iterative_telemetry/__init__.py
@@ -196,7 +196,7 @@ def _find_or_create_user_id():
     IDs are generated randomly with UUID.
     """
 
-    config_dir = user_config_dir("telemetry", "iterative")
+    config_dir = user_config_dir(os.path.join("iterative", "telemetry"), False)
     fname = os.path.join(config_dir, "user_id")
     lockfile = os.path.join(config_dir, "user_id.lock")
 

--- a/src/iterative_telemetry/__init__.py
+++ b/src/iterative_telemetry/__init__.py
@@ -222,8 +222,8 @@ def _find_or_create_user_id():
                         user_id = read_user_id(config_file_old)
                     if user_id is None:
                         user_id = generate_id()
-                with config_file.open(mode="w", encoding="utf8") as fd:
-                    json.dump({"user_id": user_id}, fd)
+                with config_file.open(mode="w", encoding="utf8") as fobj:
+                    json.dump({"user_id": user_id}, fobj)
 
             if user_id.lower() != DO_NOT_TRACK_VALUE.lower():
                 return user_id
@@ -234,8 +234,8 @@ def _find_or_create_user_id():
 
 def read_user_id(config_file: Path):
     try:
-        with config_file.open(encoding="utf8") as fd:
-            return json.load(fd)["user_id"]
+        with config_file.open(encoding="utf8") as fobj:
+            return json.load(fobj)["user_id"]
     except (FileNotFoundError, ValueError, KeyError):
         pass
     return None

--- a/src/iterative_telemetry/__init__.py
+++ b/src/iterative_telemetry/__init__.py
@@ -75,8 +75,7 @@ class IterativeTelemetryLogger:
         return (
             os.environ.get(DO_NOT_TRACK_ENV, None) is None and self.enabled()
             if callable(self.enabled)
-            else self.enabled
-            and _find_or_create_user_id() != DO_NOT_TRACK_VALUE
+            else self.enabled and _find_or_create_user_id() is not None
         )
 
     def send(
@@ -225,7 +224,8 @@ def _find_or_create_user_id():
             if not old.exists() and uid.lower() != DO_NOT_TRACK_VALUE.lower():
                 json.dump({"user_id": uid}, old.open("w", encoding="utf8"))
 
-            return uid
+            if uid.lower() != DO_NOT_TRACK_VALUE.lower():
+                return uid
     except Timeout:
         logger.debug("Failed to acquire %s", lockfile)
     return None


### PR DESCRIPTION
- [x] for cross-platform compatibility: use `appdirs.user_config_dir`'s `appauthor` even on non-Windows systems
- [x] look for legacy DVC id (fixes #13, replaces/closes #31)
- [x] ~write to legacy file~
- [x] ~expose `write_legacy` for DVC to set to `False`~
- [x] ~do not use JSON~ use JSON

vis:

- spec https://www.notion.so/iterative/Telemetry-Specification-1a0197b8e34d43a89777a4c9a00ad1fe#f24a474b773b4fcd8ff65fc65044343d
- implementation: https://github.com/iterative/terraform-provider-iterative/blob/7c800a9d178efe11ade71248915166d6b651453c/iterative/utils/analytics.go#L210