### PR TITLE
[skip ci]: use pypa/gh-action-pypi-publish@release/v1 and drop __token__

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,6 @@ jobs:
       run: nox -s build
 
     - name: Upload package
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        user: __token__
         password: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
See https://github.com/pypa/gh-action-pypi-publish#-master-branch-sunset-.

> The master branch version has been sunset. Please, change the GitHub Action version you use from master to release/v1 or use an exact tag, or a full Git commit SHA.

Also, `__token__` is the default, so no need to specify.