### PR TITLE
converts subprocess outputs to text for user ids

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
     rev: 5.10.1
     hooks:
       - id: isort
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://github.com/pycqa/flake8
     rev: 5.0.4
     hooks:
       - id: flake8

--- a/noxfile.py
+++ b/noxfile.py
@@ -37,7 +37,8 @@ def safety(session: nox.Session) -> None:
     """Scan dependencies for insecure packages."""
     session.install(".[dev]")
     session.install("safety")
-    session.run("safety", "check", "--full-report")
+    # Ignore https://github.com/pytest-dev/py/issues/287
+    session.run("safety", "check", "--full-report", "-i", "51457")
 
 
 @nox.session

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ install_requires=
 
 [options.extras_require]
 tests =
-    pytest==7.1.2
+    pytest==7.2.0
     pytest-sugar==0.9.5
     pytest-cov==3.0.0
     pytest-mock==3.8.2

--- a/src/iterative_telemetry/__init__.py
+++ b/src/iterative_telemetry/__init__.py
@@ -284,7 +284,7 @@ def _generate_github_id():
     try:
         user_id = subprocess.check_output(  # nosec B603, B607
             ["gh", "api", f"users/{actor}", "--jq", ".name, .login, .id"],
-            text=True
+            text=True,
         )
     except subprocess.SubprocessError:
         return None
@@ -317,8 +317,7 @@ def _generate_bitbucket_id():
         return None
     try:
         user_id = subprocess.check_output(  # nosec B603, B607
-            ["git", "log", "-1", "--pretty=format:'%ae'"],
-            text=True
+            ["git", "log", "-1", "--pretty=format:'%ae'"], text=True
         )
         return group_id, user_id
     except subprocess.SubprocessError:

--- a/src/iterative_telemetry/__init__.py
+++ b/src/iterative_telemetry/__init__.py
@@ -283,7 +283,8 @@ def _generate_github_id():
     group_id = f"{server_url}/{os.path.dirname(repository)}"
     try:
         user_id = subprocess.check_output(  # nosec B603, B607
-            ["gh", "api", f"users/{actor}", "--jq", ".name, .login, .id"]
+            ["gh", "api", f"users/{actor}", "--jq", ".name, .login, .id"],
+            text=True
         )
     except subprocess.SubprocessError:
         return None
@@ -316,7 +317,8 @@ def _generate_bitbucket_id():
         return None
     try:
         user_id = subprocess.check_output(  # nosec B603, B607
-            ["git", "log", "-1", "--pretty=format:'%ae'"]
+            ["git", "log", "-1", "--pretty=format:'%ae'"],
+            text=True
         )
         return group_id, user_id
     except subprocess.SubprocessError:

--- a/src/iterative_telemetry/__init__.py
+++ b/src/iterative_telemetry/__init__.py
@@ -32,6 +32,7 @@ DO_NOT_TRACK_VALUE = "do-not-track"
 
 @dataclasses.dataclass
 class TelemetryEvent:
+    # pylint: disable=multiple-statements
     interface: str
     action: str
     error: Optional[str] = None


### PR DESCRIPTION
Avoids the error below (from testing locally) by returning text instead of bytes. This should be throwing errors for GH and BB CI jobs. Has anyone noticed the metrics looking odd?

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/dave/miniforge3/lib/python3.10/os.py", line 684, in __setitem__
    value = self.encodevalue(value)
  File "/Users/dave/miniforge3/lib/python3.10/os.py", line 756, in encode
    raise TypeError("str expected, not %s" % type(value).__name__)
TypeError: str expected, not bool
```