### PR TITLE
Fix the telemetry exception handling for daemon mode

### DIFF
--- a/src/iterative_telemetry/__init__.py
+++ b/src/iterative_telemetry/__init__.py
@@ -190,10 +190,18 @@ class IterativeTelemetryLogger:
         impl(payload)
 
     def _send_daemon(self, payload):
-        cmd = (
-            f"import requests;requests.post('{self.url}',"
-            f"params={{'token':'{self.token}'}},json={payload})"
-        )
+        cmd = f"""
+import requests, logging
+try:
+    requests.post(
+        '{self.url}',
+        params={{'token':'{self.token}'}},
+        json={payload},
+        timeout=2
+    )
+except (requests.exceptions.RequestException, Exception) as e:
+    logging.debug(f'Telemetry request failed: {{str(e)}}')
+"""
 
         if os.name == "nt":
 

--- a/src/iterative_telemetry/__init__.py
+++ b/src/iterative_telemetry/__init__.py
@@ -199,7 +199,7 @@ try:
         '{self.url}',
         params={{'token':'{self.token}'}},
         json={payload},
-        timeout=2
+        timeout=10
     )
 except Exception as e:
     logger.debug(f'Telemetry request failed: {{str(e)}}')

--- a/src/iterative_telemetry/__init__.py
+++ b/src/iterative_telemetry/__init__.py
@@ -191,9 +191,8 @@ class IterativeTelemetryLogger:
 
     def _send_daemon(self, payload):
         cmd = f"""
-import requests, logging
+import requests
 
-logger = logging.getLogger("iterative-telemetry")
 try:
     requests.post(
         '{self.url}',
@@ -201,8 +200,8 @@ try:
         json={payload},
         timeout=10
     )
-except Exception as e:
-    logger.debug(f'Telemetry request failed: {{str(e)}}')
+except Exception:
+    pass
 """
 
         if os.name == "nt":

--- a/src/iterative_telemetry/__init__.py
+++ b/src/iterative_telemetry/__init__.py
@@ -192,6 +192,8 @@ class IterativeTelemetryLogger:
     def _send_daemon(self, payload):
         cmd = f"""
 import requests, logging
+
+logger = logging.getLogger("iterative-telemetry")
 try:
     requests.post(
         '{self.url}',
@@ -199,8 +201,8 @@ try:
         json={payload},
         timeout=2
     )
-except (requests.exceptions.RequestException, Exception) as e:
-    logging.debug(f'Telemetry request failed: {{str(e)}}')
+except Exception as e:
+    logger.debug(f'Telemetry request failed: {{str(e)}}')
 """
 
         if os.name == "nt":


### PR DESCRIPTION
In daemon mode, the request is made in subprocess effectively causing a
huge set of stacktrace in terminal as provided in
https://github.com/iterative/studio/issues/11282.

This handles the exception properly along with timeout for the telemetry
call.

Closes https://github.com/iterative/studio/issues/11282
